### PR TITLE
Update cassandra to latest version of Jepsen

### DIFF
--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -3,34 +3,26 @@
 This is based on [riptano's jepsen](https://github.com/riptano/jepsen/tree/cassandra/cassandra).
 
 ## Current status
-- Support Apache Cassandra 3.11.x
+- Supports Apache Cassandra 3.11.x
 - Support `collections.map-test`, `collections.set-test`, `batch-test`, `counter-test`(only add) and `lwt-test`
   - Removed `lww-test` and `mv-test`
 
 ## How to test
+
+### Docker settings
+
+You will probably need to increase the amount of memory that you make available to Docker in order to run these tests with Docker. We have had success using 8GB of memory and 2GB of swap. More, if you can spare it, is probably better.
+
 ### Start the Docker Container
 
-- Add the following line to the Docker file of a node
-  - Because C* needs Java 8
-
-```diff
---- a/docker/node/Dockerfile-ubuntu
-+++ b/docker/node/Dockerfile-ubuntu
-@@ -7,4 +7,5 @@ RUN apt-get install -y openssh-server \
-     curl faketime iproute2 iptables iputils-ping libzip4 \
-     logrotate man man-db net-tools ntpdate psmisc python rsyslog \
-     sudo unzip vim wget apt-transport-https \
-+    && apt-get update && apt-get install -y openjdk-8-jre \
-     && apt-get remove -y --purge --auto-remove systemd
-```
-
-- Run docker
+- Fire up docker
 ```sh
 cd ${JEPSEN}/docker
-./up.sh --ubuntu
+./up.sh
 ```
 
 ### Install Cassaforte
+
 - Get and install `Cassaforte` which has been modified for the new Cassandra driver
   - Modified converter in `src/clojure/clojurewerkz/cassaforte/conversion.clj`
   - Modified option methods in `src/clojure/clojurewerkz/cassaforte/query.clj`
@@ -47,4 +39,4 @@ lein install
 
 `lein run test --test lwt --nemesis bridge --join bootstrap`
 
-- See `lein run test --help` for full options
+See `lein run test --help` for full options

--- a/cassandra/project.clj
+++ b/cassandra/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/java.jmx "0.3.1"]
-                 [jepsen "0.1.11"]
+                 [jepsen "0.1.13"]
                  [clojurewerkz/cassaforte "3.0.0-alpha2-SNAPSHOT"]]
   :profiles {:dev {:plugins [[test2junit "1.4.2"]]}
              :trunk {:dependencies [[clojurewerkz/cassaforte "3.0.0-alpha2-SNAPSHOT"]]}}

--- a/cassandra/src/cassandra/batch.clj
+++ b/cassandra/src/cassandra/batch.clj
@@ -19,7 +19,6 @@
             [jepsen.checker.timeline :as timeline]
             [jepsen.control [net :as net]
              [util :as net/util]]
-            [jepsen.os.debian :as debian]
             [knossos.core :as knossos]
             [knossos.model :as model]
             [clojurewerkz.cassaforte.client :as cassandra]

--- a/cassandra/src/cassandra/collections/map.clj
+++ b/cassandra/src/cassandra/collections/map.clj
@@ -17,7 +17,6 @@
             [jepsen.checker.timeline :as timeline]
             [jepsen.control [net :as net]
              [util :as net/util]]
-            [jepsen.os.debian :as debian]
             [knossos.core :as knossos]
             [knossos.model :as model]
             [clojurewerkz.cassaforte.client :as cassandra]
@@ -54,7 +53,7 @@
                                                :primary-key [:id]}))
         ; @TODO change compaction storategy
         (cql/alter-table conn "maps"
-                          (with {:compaction-options (compaction-strategy)}))
+                         (with {:compaction-options (compaction-strategy)}))
         (cql/insert conn "maps"
                     {:id 0
                      :elements {}}))))

--- a/cassandra/src/cassandra/collections/set.clj
+++ b/cassandra/src/cassandra/collections/set.clj
@@ -17,7 +17,6 @@
             [jepsen.checker.timeline :as timeline]
             [jepsen.control [net :as net]
              [util :as net/util]]
-            [jepsen.os.debian :as debian]
             [knossos.core :as knossos]
             [knossos.model :as model]
             [clojurewerkz.cassaforte.client :as cassandra]

--- a/cassandra/src/cassandra/counter.clj
+++ b/cassandra/src/cassandra/counter.clj
@@ -111,7 +111,6 @@
   [opts]
   (merge (cassandra-test (str "counter-inc-"  (:suffix opts))
                          {:client (cql-counter-client)
-                          :model nil
                           :generator (->> (repeat 100 add)
                                           (cons r)
                                           (conductors/std-gen opts))

--- a/cassandra/src/cassandra/counter.clj
+++ b/cassandra/src/cassandra/counter.clj
@@ -17,7 +17,6 @@
             [jepsen.checker.timeline :as timeline]
             [jepsen.control [net :as net]
              [util :as net/util]]
-            [jepsen.os.debian :as debian]
             [knossos.core :as knossos]
             [clojurewerkz.cassaforte.client :as cassandra]
             [clojurewerkz.cassaforte.query :refer :all]

--- a/cassandra/src/cassandra/lwt.clj
+++ b/cassandra/src/cassandra/lwt.clj
@@ -18,7 +18,6 @@
             [jepsen.checker.timeline :as timeline]
             [jepsen.control [net :as net]
              [util :as net/util]]
-            [jepsen.os.debian :as debian]
             [knossos.core :as knossos]
             [knossos.model :as model]
             [clojurewerkz.cassaforte.client :as cassandra]

--- a/cassandra/src/cassandra/lwt.clj
+++ b/cassandra/src/cassandra/lwt.clj
@@ -130,10 +130,10 @@
   [opts]
   (merge (cassandra-test (str "lwt-" (:suffix opts))
                          {:client (CasRegisterClient. (atom false) nil)
-                          :model (model/cas-register)
                           :generator (gen/phases
                                       (->> [r w cas cas cas]
                                            (conductors/std-gen opts)))
                           :checker (checker/compose
-                                    {:linear (checker/linearizable)})})
+                                    {:linear (checker/linearizable {:model     (model/cas-register)
+                                                                    :algorithm :linear})})})
          opts))


### PR DESCRIPTION
In order for this to work you should also merge the upstream version of the docker directory in Jepsen to this repo.

