### PR TITLE
reorder restart nodes from crash

### DIFF
--- a/cassandra/src/cassandra/core.clj
+++ b/cassandra/src/cassandra/core.clj
@@ -261,10 +261,8 @@
 
 (defn wait-turn
   "A node has to wait because Cassandra node can't start when another node is bootstrapping"
-  [node test]
-  (let [decommissioned (:decommissioned test)
-        nodes (:nodes test)
-        indexed-nodes (zipmap nodes (range (count nodes)))
+  [node {:keys [decommissioned nodes]}]
+  (let [indexed-nodes (zipmap nodes (range (count nodes)))
         idx (indexed-nodes node)]
     (when-not (@decommissioned node)
       (Thread/sleep (* 1000 60 idx)))))

--- a/cassandra/src/cassandra/nemesis.clj
+++ b/cassandra/src/cassandra/nemesis.clj
@@ -60,8 +60,12 @@
                               (str "nemesis already disrupting " @nodes))
                             :no-target)
                    :stop (if-let [ns @nodes]
-                           (let [restarted (for [node ns] (c/on node (stop! test node)))]
-                            (reset! nodes nil)
+                           (let [all-nodes (:nodes test)
+                                 seed (first (cass/seed-nodes test))
+                                 all-crashed? (= (count ns) (count all-nodes))
+                                 reordered (if all-crashed? (conj (remove #(= seed %) ns) seed) ns)
+                                 restarted (for [node reordered] (c/on node (stop! test node)))]
+                             (reset! nodes nil)
                              restarted)
                            :not-started)))))
 


### PR DESCRIPTION
After all nodes crash, nemesis restarts a seed node at first.

Jepsen tests failed because some nodes failed to restart.
It was caused by the nemesis restarted nodes in random order after all nodes crashed
Non-seed nodes failed to restart because the nodes couldn't find the seed node.