### PR TITLE
Seed nodes has to return a collection

### DIFF
--- a/cassandra/src/cassandra/core.clj
+++ b/cassandra/src/cassandra/core.clj
@@ -140,7 +140,7 @@
   "Get a list of seed nodes"
   [test]
   (if (= (:rf test) 1)
-    (first (:nodes test))
+    (take 1 (:nodes test))
     (take (dec (:rf test)) (:nodes test))))
 
 (defn nodetool


### PR DESCRIPTION
If it does not the subsequent join on a string will cause errors, e.g. `(str/join "," "n1") --> "n,1"`